### PR TITLE
Fix invalid best score parsing

### DIFF
--- a/index.html
+++ b/index.html
@@ -251,7 +251,11 @@
             let suspiciousThreshold = 100;
             let totalValidAttempts = 5;
             let state = "idle";
-            let bestScore = localStorage.getItem('bestReactionScore') ? parseFloat(localStorage.getItem('bestReactionScore')) : null;
+            let storedBest = localStorage.getItem('bestReactionScore');
+            let bestScore = storedBest !== null ? parseFloat(storedBest) : null;
+            if (isNaN(bestScore)) {
+                bestScore = null;
+            }
             let startTime = 0;
             let timerId = null;
 


### PR DESCRIPTION
## Summary
- protect against invalid values in `localStorage` when reading `bestReactionScore`

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849647c2884832f881f6acf8465f10a